### PR TITLE
fix: compilation error

### DIFF
--- a/verifier/main.go
+++ b/verifier/main.go
@@ -34,7 +34,7 @@ func DefaultVerifier() (*core.Verifier, error) {
 		return nil, fmt.Errorf("%s: %w", core.ERROR_INIT_DB, err)
 	}
 
-	monitor := monitor.NewCrtshMonitor(context.Background())
+	monitor := monitor.DefaultCrtshMonitor(context.Background())
 
 	notifier, err := notifier.DefaultBrowserNotifier()
 	if err != nil {


### PR DESCRIPTION
use default creating method for monitor instead of new